### PR TITLE
Add support for python on windows.

### DIFF
--- a/lua/mason-nvim-dap/mappings/adapters.lua
+++ b/lua/mason-nvim-dap/mappings/adapters.lua
@@ -17,9 +17,12 @@ M.delve = {
 	},
 }
 
+local PYTHON_DIR = require('mason-registry').get_package('debugpy'):get_install_path() ..
+		'/venv/Scripts/python'
 M.python = {
 	type = 'executable',
-	command = 'debugpy-adapter',
+	command = PYTHON_DIR,
+	args = { '-m', "debugpy.adapter" },
 }
 
 M.node2 = {


### PR DESCRIPTION
Tested and works on windows should work on linux but needs to be tested, there is a python shell window that pops up but nothing that can be done about that, not sure if same thing happens on linux