### PR TITLE
Add Windows support for node

### DIFF
--- a/lua/mason-nvim-dap/mappings/adapters.lua
+++ b/lua/mason-nvim-dap/mappings/adapters.lua
@@ -22,9 +22,12 @@ M.python = {
 	command = 'debugpy-adapter',
 }
 
+local NODEDEBUG_DIR = require('mason-registry').get_package('node-debug2-adapter'):get_install_path() ..
+		'/out/src/nodeDebug.js'
 M.node2 = {
 	type = 'executable',
-	command = 'node-debug2-adapter',
+	command = 'node',
+	args = { NODEDEBUG_DIR }
 }
 
 M.chrome = {


### PR DESCRIPTION
Tested and works on windows works fine, needs testing on linux, i decided to ignore the adapter script because it was easier to setup for both OS's that way.