### PR TITLE
feat: support overriding filetypes for adapters

### DIFF
--- a/lua/mason-nvim-dap/automatic_setup.lua
+++ b/lua/mason-nvim-dap/automatic_setup.lua
@@ -4,7 +4,7 @@ local _ = require('mason-core.functional')
 -- @param adapter string
 return _.memoize(function(adapter)
 	local adapters = require('mason-nvim-dap.mappings.adapters')
-	local filetypes = require('mason-nvim-dap.mappings.filetypes')
+	local filetypes = require('mason-nvim-dap.mappings.filetypes').adapter_to_configs
 	local configurations = require('mason-nvim-dap.mappings.configurations')
 
 	local dap = require('dap')

--- a/lua/mason-nvim-dap/automatic_setup.lua
+++ b/lua/mason-nvim-dap/automatic_setup.lua
@@ -4,7 +4,7 @@ local _ = require('mason-core.functional')
 -- @param adapter string
 return _.memoize(function(adapter)
 	local adapters = require('mason-nvim-dap.mappings.adapters')
-	local filetypes = require('mason-nvim-dap.mappings.filetypes').adapter_to_configs
+	local filetypes = require('mason-nvim-dap.mappings.filetypes')
 	local configurations = require('mason-nvim-dap.mappings.configurations')
 
 	local dap = require('dap')

--- a/lua/mason-nvim-dap/mappings/filetypes.lua
+++ b/lua/mason-nvim-dap/mappings/filetypes.lua
@@ -18,6 +18,7 @@ M.adapter_to_configs = {
 	['kotlin'] = { 'kotlin' },
 }
 
-M.adapter_to_configs = vim.tbl_deep_extend('force', M.adapter_to_configs, settings.current.automatic_setup.filetypes or {})
+M.adapter_to_configs =
+	vim.tbl_deep_extend('force', M.adapter_to_configs, settings.current.automatic_setup.filetypes or {})
 
 return M

--- a/lua/mason-nvim-dap/mappings/filetypes.lua
+++ b/lua/mason-nvim-dap/mappings/filetypes.lua
@@ -1,8 +1,7 @@
 local _ = require('mason-core.functional')
+local settings = require('mason-nvim-dap.settings')
 
-local M = {}
-
-M.adapter_to_configs = {
+local M = {
 	['bash'] = { 'sh' },
 	['chrome'] = { 'javascriptreact', 'typescriptreact', 'typescript', 'javascript' },
 	['coreclr'] = { 'cs' },
@@ -16,5 +15,7 @@ M.adapter_to_configs = {
 	['mix_task'] = { 'elixir' },
 	['kotlin'] = { 'kotlin' },
 }
+
+M = vim.tbl_deep_extend('force', M, settings.current.automatic_setup.filetypes or {})
 
 return M

--- a/lua/mason-nvim-dap/mappings/filetypes.lua
+++ b/lua/mason-nvim-dap/mappings/filetypes.lua
@@ -1,7 +1,9 @@
 local _ = require('mason-core.functional')
 local settings = require('mason-nvim-dap.settings')
 
-local M = {
+local M = {}
+
+M.adapter_to_configs = {
 	['bash'] = { 'sh' },
 	['chrome'] = { 'javascriptreact', 'typescriptreact', 'typescript', 'javascript' },
 	['coreclr'] = { 'cs' },
@@ -16,6 +18,6 @@ local M = {
 	['kotlin'] = { 'kotlin' },
 }
 
-M = vim.tbl_deep_extend('force', M, settings.current.automatic_setup.filetypes or {})
+M.adapter_to_configs = vim.tbl_deep_extend('force', M.adapter_to_configs, settings.current.automatic_setup.filetypes or {})
 
 return M

--- a/lua/mason-nvim-dap/settings.lua
+++ b/lua/mason-nvim-dap/settings.lua
@@ -22,7 +22,7 @@ local DEFAULT_SETTINGS = {
 	-- Can either be:
 	-- 	- false: Dap is not automatically configured.
 	-- 	- true: Dap is automatically configured.
-	-- 	- {adapters: {ADAPTER: {}, }, configurations: {ADAPTER: {}, }}. Allows overriding default configuration.
+	-- 	- {adapters: {ADAPTER: {}, }, configurations: {ADAPTER: {}, }, filetypes: {ADAPTER: {}, }}. Allows overriding default configuration.
 	automatic_setup = false,
 }
 


### PR DESCRIPTION
First of all, thank you for this plugin, it greatly reduced my config size.

Use case:
I used `simrat39/rust-tools.nvim` and would like it to configure my dap instead of `mason-nvim-dap.nvim`.

Solution:
This PR allow me to do things like:
```lua
require('mason-nvim-dap').setup {
  automatic_setup = { filetypes = { codelldb = { 'c', 'cpp' } } },
}
``` 
This way I don't have to override the entire handler for codelldb and still let `mason-nvim-dap.nvim` configure c and cpp for me.