### PR TITLE
bugfix(python): use virtual environment if activated

### DIFF
--- a/lua/mason-nvim-dap/mappings/configurations.lua
+++ b/lua/mason-nvim-dap/mappings/configurations.lua
@@ -47,6 +47,7 @@ M.bash = {
 	},
 }
 
+local venv_path = os.getenv('VIRTUAL_ENV') or os.getenv('CONDA_PREFIX')
 M.python = {
 	{
 		-- The first three options are required by nvim-dap
@@ -54,6 +55,7 @@ M.python = {
 		request = 'launch',
 		name = 'Python: Launch file',
 		program = '${file}', -- This configuration will launch the current file if used.
+		pythonPath = venv_path and (venv_path .. '/bin/python') or nil,
 	},
 }
 


### PR DESCRIPTION
This lets `nvim-dap` automatically detect if a python virtual environment is activated and uses it rather than the system installation of python. This also aligns with how `pyright` and python LSP behaves