### PR TITLE
Fix dart & flutter path on windows

### DIFF
--- a/lua/mason-nvim-dap/mappings/configurations.lua
+++ b/lua/mason-nvim-dap/mappings/configurations.lua
@@ -214,13 +214,20 @@ M.kotlin = {
 	},
 }
 
+local function flutter_path()
+	return vim.loop.os_uname().sysname == 'Windows_NT' and 'C:\\src\\flutter' or os.getenv('HOME') .. '/flutter'
+end
+
 M.dart = {
 	{
 		type = 'dart',
 		request = 'launch',
 		name = 'Launch flutter',
-		dartSdkPath = os.getenv('HOME') .. '/flutter/bin/cache/dart-sdk/',
-		flutterSdkPath = os.getenv('HOME') .. '/flutter',
+		-- windows don't really have a standard install path
+		-- best effort guess is the instructed install path from:
+		-- https://docs.flutter.dev/get-started/install/windows
+		dartSdkPath = flutter_path() .. '/bin/cache/dart-sdk/',
+		flutterSdkPath = flutter_path(),
 		program = '${workspaceFolder}/lib/main.dart',
 		cwd = '${workspaceFolder}',
 	},


### PR DESCRIPTION
On windows, `HOME` environment variable doesn't exist, hence `os.getenv('HOME')` will return nil which causes `attempt to concatenate a nil value`.

This PR fixes that with an best effort guess of flutter's installation path on windows. A more sophisticated approach would be to find the install path dynamically from `$PATH` if required, something similar to what [flutter-tools.nvim](https://github.com/akinsho/flutter-tools.nvim/blob/ae0be3cef35c0cb41d6c7f814a19b3402d50fd7a/lua/flutter-tools/executable.lua#L18) do. Thought i'd imagine that would require some refactoring though.