### PR TITLE
fix(codelldb): use vim.fn.exepath for command (#51)

### DIFF
--- a/lua/mason-nvim-dap/mappings/adapters.lua
+++ b/lua/mason-nvim-dap/mappings/adapters.lua
@@ -63,13 +63,14 @@ M.codelldb = {
 	type = 'server',
 	port = '${port}',
 	executable = {
-		command = 'codelldb',
+		command = vim.fn.exepath('codelldb'),
 		args = { '--port', '${port}' },
 	},
 }
 if vim.fn.has('win32') == 1 then
 	M.codelldb.executable.detached = false
 end
+
 M.mix_task = {
 	type = 'executable',
 	command = 'elixir-ls-debugger', -- https://github.com/williamboman/mason.nvim/blob/d97579ccd5689f9c6c365e841ea99c27954112ec/lua/mason-registry/elixir-ls/init.lua#L26


### PR DESCRIPTION
Mason.nvim utilizes symlinks to organize package files. On Windows symlink support is complicated and so mason chooses to use .cmd script files to simplify things. Setting "command" to "codelldb" will only look for files with the name "codelldb", i.e. it will not find "codelldb.cmd".

This commit changes "command" to use vim.fn.exepath() which seems to find any executable file with an equivalent stem. This means it will find both files "codelldb" and "codelldb.cmd".