### PR TITLE
fix: use vim.fn.exepath for all adapter commands

### DIFF
--- a/lua/mason-nvim-dap/mappings/adapters.lua
+++ b/lua/mason-nvim-dap/mappings/adapters.lua
@@ -4,7 +4,7 @@ local M = {}
 
 M.bash = {
 	type = 'executable',
-	command = 'bash-debug-adapter',
+	command = vim.fn.exepath('bash-debug-adapter'),
 }
 
 -- https://github.com/mfussenegger/nvim-dap/wiki/Debug-Adapter-installation#go-using-delve-directly
@@ -12,46 +12,46 @@ M.delve = {
 	type = 'server',
 	port = '${port}',
 	executable = {
-		command = 'dlv',
+		command = vim.fn.exepath('dlv'),
 		args = { 'dap', '-l', '127.0.0.1:${port}' },
 	},
 }
 
 M.python = {
 	type = 'executable',
-	command = 'debugpy-adapter',
+	command = vim.fn.exepath('debugpy-adapter'),
 }
 
 M.node2 = {
 	type = 'executable',
-	command = 'node-debug2-adapter',
+	command = vim.fn.exepath('node-debug2-adapter'),
 }
 
 M.chrome = {
 	type = 'executable',
-	command = 'chrome-debug-adapter',
+	command = vim.fn.exepath('chrome-debug-adapter'),
 }
 
 M.firefox = {
 	type = 'executable',
-	command = 'firefox-debug-adapter',
+	command = vim.fn.exepath('firefox-debug-adapter'),
 }
 
 M.php = {
 	type = 'executable',
-	command = 'php-debug-adapter',
+	command = vim.fn.exepath('php-debug-adapter'),
 }
 
 M.coreclr = {
 	type = 'executable',
-	command = 'netcoredbg',
+	command = vim.fn.exepath('netcoredbg'),
 	args = { '--interpreter=vscode' },
 }
 
 M.cppdbg = {
 	id = 'cppdbg',
 	type = 'executable',
-	command = 'OpenDebugAD7',
+	command = vim.fn.exepath('OpenDebugAD7'),
 }
 if vim.fn.has('win32') == 1 then
 	M.cppdbg.options = {
@@ -73,19 +73,19 @@ end
 
 M.mix_task = {
 	type = 'executable',
-	command = 'elixir-ls-debugger', -- https://github.com/williamboman/mason.nvim/blob/d97579ccd5689f9c6c365e841ea99c27954112ec/lua/mason-registry/elixir-ls/init.lua#L26
+	command = vim.fn.exepath('elixir-ls-debugger'), -- https://github.com/williamboman/mason.nvim/blob/d97579ccd5689f9c6c365e841ea99c27954112ec/lua/mason-registry/elixir-ls/init.lua#L26
 	args = {},
 }
 
 M.kotlin = {
 	type = 'executable',
-	command = 'kotlin-debug-adapter',
+	command = vim.fn.exepath('kotlin-debug-adapter'),
 	args = { '--interpreter=vscode' },
 }
 
 M.dart = {
 	type = 'executable',
-	command = 'dart-debug-adapter',
+	command = vim.fn.exepath('dart-debug-adapter'),
 	args = { 'flutter' },
 }
 


### PR DESCRIPTION
Fixes #51 in the same manner as #52 but for all other adapters.

Tested on Windows with `cpptools` and it works as expected.