### PR TITLE
docs: add installation instructions for lazy.nvim

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,16 @@ It is recommended to use this extension if you use `mason.nvim` and `nvim-dap`. 
 
 # Installation
 
+## [Lazy](https://github.com/folke/lazy.nvim)
+
+```lua
+{
+    "williamboman/mason.nvim",
+    "mfussenegger/nvim-dap",
+    "jay-babu/mason-nvim-dap.nvim",
+}
+```
+
 ## [Packer](https://github.com/wbthomason/packer.nvim)
 
 ```lua


### PR DESCRIPTION
Added instructions in the README for how to use mason-nvim-dap with Lazy.nvim as a package manager.
