### PR TITLE
feat!: 2.0

### DIFF
--- a/lua/mason-nvim-dap/automatic_setup.lua
+++ b/lua/mason-nvim-dap/automatic_setup.lua
@@ -2,19 +2,17 @@ local Optional = require('mason-core.optional')
 local _ = require('mason-core.functional')
 
 -- @param adapter string
-return _.memoize(function(adapter)
-	local adapters = require('mason-nvim-dap.mappings.adapters')
-	local filetypes = require('mason-nvim-dap.mappings.filetypes').adapter_to_configs
-	local configurations = require('mason-nvim-dap.mappings.configurations')
-
+return _.memoize(function(config)
 	local dap = require('dap')
-	Optional.of_nilable(adapters[adapter]):map(function(adapter_config)
-		dap.adapters[adapter] = adapter_config
-		local configuration = configurations[adapter] or {}
+
+	Optional.of_nilable(config.adapters):map(function(adapter_config)
+		dap.adapters[config.name] = adapter_config
+		local configuration = config.configurations or {}
 		if not vim.tbl_isempty(configuration) then
-			for _, filetype in ipairs(filetypes[adapter]) do
+			for _, filetype in ipairs(config.filetypes) do
 				dap.configurations[filetype] = vim.list_extend(dap.configurations[filetype] or {}, configuration)
 			end
 		end
 	end)
+	return config
 end)

--- a/lua/mason-nvim-dap/ensure_installed.lua
+++ b/lua/mason-nvim-dap/ensure_installed.lua
@@ -13,7 +13,7 @@ local function resolve_package(nvim_dap_adapter_name)
 	end)
 end
 
-return function()
+local function ensure_installed()
 	local Package = require('mason-core.package')
 	for _, source_identifier in ipairs(settings.current.ensure_installed) do
 		local source_name, version = Package.Parse(source_identifier)
@@ -36,4 +36,12 @@ return function()
 			end
 		)
 	end
+end
+
+if registry.refresh then
+	return function()
+		registry.refresh(vim.schedule_wrap(ensure_installed))
+	end
+else
+	return ensure_installed
 end

--- a/lua/mason-nvim-dap/mappings/adapters.lua
+++ b/lua/mason-nvim-dap/mappings/adapters.lua
@@ -89,6 +89,4 @@ M.dart = {
 	args = { 'flutter' },
 }
 
-M = require('mason-nvim-dap.internal.overrides.func_or_extend')(settings.current.automatic_setup.adapters or {}, M)
-
 return M

--- a/lua/mason-nvim-dap/mappings/configurations.lua
+++ b/lua/mason-nvim-dap/mappings/configurations.lua
@@ -233,9 +233,4 @@ M.dart = {
 	},
 }
 
-M = require('mason-nvim-dap.internal.overrides.func_or_extend')(
-	settings.current.automatic_setup.configurations or {},
-	M
-)
-
 return M

--- a/lua/mason-nvim-dap/mappings/filetypes.lua
+++ b/lua/mason-nvim-dap/mappings/filetypes.lua
@@ -1,9 +1,7 @@
 local _ = require('mason-core.functional')
 local settings = require('mason-nvim-dap.settings')
 
-local M = {}
-
-M.adapter_to_configs = {
+local M = {
 	['bash'] = { 'sh' },
 	['chrome'] = { 'javascriptreact', 'typescriptreact', 'typescript', 'javascript' },
 	['codelldb'] = { 'c', 'cpp', 'rust' },
@@ -18,7 +16,5 @@ M.adapter_to_configs = {
 	['php'] = { 'php' },
 	['python'] = { 'python' },
 }
-
-M = require('mason-nvim-dap.internal.overrides.func_or_extend')(settings.current.automatic_setup.filetypes or {}, M)
 
 return M

--- a/lua/mason-nvim-dap/settings.lua
+++ b/lua/mason-nvim-dap/settings.lua
@@ -1,6 +1,9 @@
 local M = {}
 
 ---@class MasonNvimDapSettings
+---@field handlers table | nil
+---@field ensure_installed table
+---@field automatic_installation boolean
 local DEFAULT_SETTINGS = {
 	-- A list of adapters to automatically install if they're not already installed. Example: { "stylua" }
 	-- This setting has no relation with the `automatic_installation` setting.
@@ -14,15 +17,7 @@ local DEFAULT_SETTINGS = {
 	--   - { exclude: string[] }: All adapters set up via mason-nvim-dap, except the ones provided in the list, are automatically installed.
 	--       Example: automatic_installation = { exclude = { "python", "delve" } }
 	automatic_installation = false,
-	-- Whether adapters that are installed in mason should be automatically set up in dap.
-	-- Removes the need to set up dap manually.
-	-- See mappings.adapters and mappings.configurations for settings.
-	-- Can either be:
-	-- 	- false: Dap is not automatically configured.
-	-- 	- true: Dap is automatically configured.
-	-- 	- {adapters: {ADAPTER: {}, }, configurations: {configuration: {}, }, filetypes: {filetype: {}, }}. Allows overriding default configuration.
-	-- 	- {adapters: function(default), configurations: function(default), filetypes: function(default), }. Allows modifying the default configuration passed in via function.
-	automatic_setup = false,
+	handlers = nil,
 }
 
 M._DEFAULT_SETTINGS = DEFAULT_SETTINGS
@@ -30,15 +25,11 @@ M.current = M._DEFAULT_SETTINGS
 
 ---@param opts MasonNvimDapSettings
 function M.set(opts)
-	if opts.automatic_setup == true then
-		opts.automatic_setup = {}
-	end
-
 	M.current = vim.tbl_deep_extend('force', M.current, opts)
 	vim.validate({
 		ensure_installed = { M.current.ensure_installed, 'table', true },
 		automatic_installation = { M.current.automatic_installation, { 'boolean', 'table' }, true },
-		automatic_setup = { M.current.automatic_setup, { 'boolean', 'table', 'function' }, true },
+		handlers = { M.current.handlers, { 'table' }, true },
 	})
 end
 


### PR DESCRIPTION
----

Migration Guide:

1. Move `setup_handlers` table to `setup({handlers = TABLE})`.
2. To disable `automatic_setup`, provide an empty function to `handlers` like `handlers = {function() end,}`
3. Overriding configuration per adapter needs to be done in the handler table now