### PR TITLE
fix: remove not used language_mappings defition

### DIFF
--- a/lua/mason-nvim-dap/api/command.lua
+++ b/lua/mason-nvim-dap/api/command.lua
@@ -6,10 +6,8 @@ local _ = require('mason-core.functional')
 --@async
 --@param user_args string[]: The arguments, as provided by the user.
 local function parse_packages_from_user_args(user_args)
-	local registry = require('mason-registry')
 	local Package = require('mason-core.package')
 	local source_mappings = require('mason-nvim-dap.mappings.source')
-	local language_mappings = require('mason.mappings.language')
 
 	return _.filter_map(function(source_specifier)
 		local source_name, version = Package.Parse(source_specifier)


### PR DESCRIPTION
The package `mason.mappings.language` does not exists and is always raising the
error:
```
   Error  09:11:32 msg_show.lua_error   DapInstall delve Error executing Lua callback: .../share/nvim/lazy/lazy.nvim/lua/lazy/core/handler/cmd.lua:45: Vim:Error executing Lua callback: ...y/mason-nvim-dap.nvim/lua/mason-nvim-dap/api/command.lua:12: module 'mason.mappings.language' not found:
	no field package.preload['mason.mappings.language']
cache_loader: module mason.mappings.language not found
cache_loader_lib: module mason.mappings.language not found
	no file './mason/mappings/language.lua'
	no file '/usr/local/share/luajit-2.1.0-beta3/mason/mappings/language.lua'
	no file '/usr/local/share/lua/5.1/mason/mappings/language.lua'
	no file '/usr/local/share/lua/5.1/mason/mappings/language/init.lua'
	no file './mason/mappings/language.so'
	no file '/usr/local/lib/lua/5.1/mason/mappings/language.so'
	no file '/usr/local/lib/lua/5.1/loadall.so'
	no file './mason.so'
	no file '/usr/local/lib/lua/5.1/mason.so'
	no file '/usr/local/lib/lua/5.1/loadall.so'
stack traceback:
	[C]: in function 'error'
	...share/nvim/lazy/mason.nvim/lua/mason-core/async/init.lua:113: in function 'callback'
	...share/nvim/lazy/mason.nvim/lua/mason-core/async/init.lua:91: in function 'step'
	...share/nvim/lazy/mason.nvim/lua/mason-core/async/init.lua:96: in function 'DapInstall'
	...y/mason-nvim-dap.nvim/lua/mason-nvim-dap/api/command.lua:113: in function <...y/mason-nvim-dap.nvim/lua/mason-nvim-dap/api/command.lua:112>
	[C]: in function 'cmd'
	.../share/nvim/lazy/lazy.nvim/lua/lazy/core/handler/cmd.lua:45: in function <.../share/nvim/lazy/lazy.nvim/lua/lazy/core/handler/cmd.lua:16>
stack traceback:
	[C]: in function 'cmd'
	.../share/nvim/lazy/lazy.nvim/lua/lazy/core/handler/cmd.lua:45: in function <.../share/nvim/lazy/lazy.nvim/lua/lazy/core/handler/cmd.lua:16>
```

As `language_mappings` is not used, I'm removing it.
