### PR TITLE
feat: Add haskell to list of supported debug adapters

### DIFF
--- a/lua/mason-nvim-dap/mappings/adapters/haskell.lua
+++ b/lua/mason-nvim-dap/mappings/adapters/haskell.lua
@@ -1,4 +1,4 @@
 return {
-  type = 'executable',
-  command = vim.fn.exepath('haskell-debug-adapter'),
+	type = 'executable',
+	command = vim.fn.exepath('haskell-debug-adapter'),
 }

--- a/lua/mason-nvim-dap/mappings/adapters/haskell.lua
+++ b/lua/mason-nvim-dap/mappings/adapters/haskell.lua
@@ -1,5 +1,4 @@
 return {
   type = 'executable',
   command = vim.fn.exepath('haskell-debug-adapter'),
-  args = { '--hackage-version=0.0.39.0' },
 }

--- a/lua/mason-nvim-dap/mappings/adapters/haskell.lua
+++ b/lua/mason-nvim-dap/mappings/adapters/haskell.lua
@@ -1,0 +1,5 @@
+return {
+  type = 'executable',
+  command = vim.fn.exepath('haskell-debug-adapter'),
+  args = { '--hackage-version=0.0.39.0' },
+}

--- a/lua/mason-nvim-dap/mappings/configurations.lua
+++ b/lua/mason-nvim-dap/mappings/configurations.lua
@@ -238,20 +238,6 @@ M.dart = {
 	},
 }
 
-local function stack_path()
-	local stack_path = ''
-	-- require('mason-registry').has_package('haskell=debug-adapter')
-	if
-			require('mason-registry').has_package('haskell-debug-adapter')
-			and require('mason-registry').get_package('haskell-debug-adapter'):is_installed()
-	then
-		-- get stack_path executable
-		stack_path = require('mason-registry').get_package('haskell-debug-adapter'):get_install_path() .. '/stack'
-	end
-
-	return stack_path
-end
-
 M.haskell = {
 	{
 		type = 'haskell',
@@ -266,9 +252,7 @@ M.haskell = {
 		ghciPrompt = 'λ: ',
 		-- Adjust the prompt to the prompt you see when you invoke the stack ghci command below
 		ghciInitialPrompt = 'λ: ',
-		-- even if the stack_path is invalid, we have the fallback of a user having ghci in $PATH
-		ghciCmd = stack_path()
-				.. 'ghci --test --no-load --no-build --main-is TARGET --ghci-options -fprint-evld-with-show',
+		ghciCmd = 'stack ghci --test --no-load --no-build --main-is TARGET --ghci-options -fprint-evld-with-show',
 	},
 }
 

--- a/lua/mason-nvim-dap/mappings/configurations.lua
+++ b/lua/mason-nvim-dap/mappings/configurations.lua
@@ -29,11 +29,11 @@ M.delve = {
 
 local BASHDB_DIR = ''
 if
-		require('mason-registry').has_package('bash-debug-adapter')
-		and require('mason-registry').get_package('bash-debug-adapter'):is_installed()
+	require('mason-registry').has_package('bash-debug-adapter')
+	and require('mason-registry').get_package('bash-debug-adapter'):is_installed()
 then
 	BASHDB_DIR = require('mason-registry').get_package('bash-debug-adapter'):get_install_path()
-			.. '/extension/bashdb_dir'
+		.. '/extension/bashdb_dir'
 end
 
 M.bash = {

--- a/lua/mason-nvim-dap/mappings/configurations.lua
+++ b/lua/mason-nvim-dap/mappings/configurations.lua
@@ -29,11 +29,11 @@ M.delve = {
 
 local BASHDB_DIR = ''
 if
-	require('mason-registry').has_package('bash-debug-adapter')
-	and require('mason-registry').get_package('bash-debug-adapter'):is_installed()
+		require('mason-registry').has_package('bash-debug-adapter')
+		and require('mason-registry').get_package('bash-debug-adapter'):is_installed()
 then
 	BASHDB_DIR = require('mason-registry').get_package('bash-debug-adapter'):get_install_path()
-		.. '/extension/bashdb_dir'
+			.. '/extension/bashdb_dir'
 end
 
 M.bash = {
@@ -105,7 +105,6 @@ M.chrome = {
 		name = 'Chrome: Debug',
 		type = 'chrome',
 		request = 'attach',
-
 		program = '${file}',
 		cwd = vim.fn.getcwd(),
 		sourceMaps = true,
@@ -120,7 +119,6 @@ M.firefox = {
 		name = 'Firefox: Debug',
 		type = 'firefox',
 		request = 'launch',
-
 		reAttach = true,
 		url = 'http://localhost:3000',
 		webRoot = '${workspaceFolder}',
@@ -237,6 +235,40 @@ M.dart = {
 		flutterSdkPath = flutter_path(),
 		program = '${workspaceFolder}/lib/main.dart',
 		cwd = '${workspaceFolder}',
+	},
+}
+
+local function stack_path()
+	local stack_path = ''
+	-- require('mason-registry').has_package('haskell=debug-adapter')
+	if
+			require('mason-registry').has_package('haskell-debug-adapter')
+			and require('mason-registry').get_package('haskell-debug-adapter'):is_installed()
+	then
+		-- get stack_path executable
+		stack_path = require('mason-registry').get_package('haskell-debug-adapter'):get_install_path() .. '/stack'
+	end
+
+	return stack_path
+end
+
+M.haskell = {
+	{
+		type = 'haskell',
+		request = 'launch',
+		name = 'Debug',
+		workspace = '${workspaceFolder}',
+		startup = '${file}',
+		stopOnEntry = true,
+		logFile = vim.fn.stdpath('data') .. '/haskell-dap.log',
+		logLevel = 'WARNING',
+		ghciEnv = vim.empty_dict(),
+		ghciPrompt = 'λ: ',
+		-- Adjust the prompt to the prompt you see when you invoke the stack ghci command below
+		ghciInitialPrompt = 'λ: ',
+		-- even if the stack_path is invalid, we have the fallback of a user having ghci in $PATH
+		ghciCmd = stack_path()
+				.. 'ghci --test --no-load --no-build --main-is TARGET --ghci-options -fprint-evld-with-show',
 	},
 }
 

--- a/lua/mason-nvim-dap/mappings/filetypes.lua
+++ b/lua/mason-nvim-dap/mappings/filetypes.lua
@@ -15,6 +15,7 @@ local M = {
 	['node2'] = { 'javascriptreact', 'typescriptreact', 'typescript', 'javascript' },
 	['php'] = { 'php' },
 	['python'] = { 'python' },
+	['haskell'] = { 'haskell' },
 }
 
 return M

--- a/lua/mason-nvim-dap/mappings/source.lua
+++ b/lua/mason-nvim-dap/mappings/source.lua
@@ -22,6 +22,7 @@ M.nvim_dap_to_package = {
 	['elixir'] = 'elixir-ls',
 	['kotlin'] = 'kotlin-debug-adapter',
 	['dart'] = 'dart-debug-adapter',
+	['haskell'] = 'haskell-debug-adapter',
 }
 
 M.package_to_nvim_dap = _.invert(M.nvim_dap_to_package)


### PR DESCRIPTION
Hi there,

I made a pull onto mason-registry to add haskell-debug-adapter so now we should be able to integrate it!

The default setup basically exactly what nvim-dap recommends. It should all be good, not sure entirely if it will work on windows as we had some errors with mason-registry with windows being funky but hopefully it's ok.

Please do comment on any changes that I could make, I would really appreciate any feedback.