### PR TITLE
fix: changed default prompt to be the fresh-installed stack version

### DIFF
--- a/lua/mason-nvim-dap/mappings/configurations.lua
+++ b/lua/mason-nvim-dap/mappings/configurations.lua
@@ -29,11 +29,11 @@ M.delve = {
 
 local BASHDB_DIR = ''
 if
-		require('mason-registry').has_package('bash-debug-adapter')
-		and require('mason-registry').get_package('bash-debug-adapter'):is_installed()
+	require('mason-registry').has_package('bash-debug-adapter')
+	and require('mason-registry').get_package('bash-debug-adapter'):is_installed()
 then
 	BASHDB_DIR = require('mason-registry').get_package('bash-debug-adapter'):get_install_path()
-			.. '/extension/bashdb_dir'
+		.. '/extension/bashdb_dir'
 end
 
 M.bash = {

--- a/lua/mason-nvim-dap/mappings/configurations.lua
+++ b/lua/mason-nvim-dap/mappings/configurations.lua
@@ -29,11 +29,11 @@ M.delve = {
 
 local BASHDB_DIR = ''
 if
-	require('mason-registry').has_package('bash-debug-adapter')
-	and require('mason-registry').get_package('bash-debug-adapter'):is_installed()
+		require('mason-registry').has_package('bash-debug-adapter')
+		and require('mason-registry').get_package('bash-debug-adapter'):is_installed()
 then
 	BASHDB_DIR = require('mason-registry').get_package('bash-debug-adapter'):get_install_path()
-		.. '/extension/bashdb_dir'
+			.. '/extension/bashdb_dir'
 end
 
 M.bash = {
@@ -249,9 +249,9 @@ M.haskell = {
 		logFile = vim.fn.stdpath('data') .. '/haskell-dap.log',
 		logLevel = 'WARNING',
 		ghciEnv = vim.empty_dict(),
-		ghciPrompt = 'λ: ',
+		ghciPrompt = 'ghci>',
 		-- Adjust the prompt to the prompt you see when you invoke the stack ghci command below
-		ghciInitialPrompt = 'λ: ',
+		ghciInitialPrompt = 'ghci>',
 		ghciCmd = 'stack ghci --test --no-load --no-build --main-is TARGET --ghci-options -fprint-evld-with-show',
 	},
 }


### PR DESCRIPTION
Hi again,

To test that everything was OK one last time. I did a fresh install of stack and everything without configuration. I found that I was unable to get the debug adapter to work. I realized that with a fresh install of ghcup, stack, and ghci, the prompt for ghci is now 'ghci>'. 

The fact that the haskell-debug-adapter is dependent on the prompt is a design flaw in my opinion. However setting the default value as the freshly-installed value should be fine for now.