### PR TITLE
fix: use ghci-dap and -ignore-dot-ghci

### DIFF
--- a/lua/mason-nvim-dap/mappings/configurations.lua
+++ b/lua/mason-nvim-dap/mappings/configurations.lua
@@ -251,8 +251,10 @@ M.haskell = {
 		ghciEnv = vim.empty_dict(),
 		ghciPrompt = 'ghci>',
 		-- Adjust the prompt to the prompt you see when you invoke the stack ghci command below
-		ghciInitialPrompt = 'ghci>',
-		ghciCmd = 'stack ghci --test --no-load --no-build --main-is TARGET --ghci-options -fprint-evld-with-show',
+		ghciInitialPrompt = '>',
+		ghciCmd = 'stack ghci --with-ghc='
+			.. vim.fn.exepath('ghci-dap')
+			.. ' --test --no-load --no-build --main-is TARGET --ghci-options -fprint-evld-with-show --ghci-options -ignore-dot-ghci',
 	},
 }
 


### PR DESCRIPTION
Hi again,

I'm really sorry to be making so many pull requests, but I had a conversation with the author of the haskell-debug-adapter and came to the conclusion that it may be good to remove any potential user cofiguration from stalling the initialisation stage of teh debugger. We now use -ignore-dot-ghci to ensure ghci runs completely "fresh".

We now also use ghci-dap as the ghc engine, which makes debugging more convenient.