### PR TITLE
fix: Fixed codelldb and cppdbg failing to setup on windows.

### DIFF
--- a/lua/mason-nvim-dap/mappings/adapters/codelldb.lua
+++ b/lua/mason-nvim-dap/mappings/adapters/codelldb.lua
@@ -8,7 +8,7 @@ local M = {
 }
 
 if vim.fn.has('win32') == 1 then
-	M.codelldb.executable.detached = false
+	M.executable.detached = false
 end
 
 return M

--- a/lua/mason-nvim-dap/mappings/adapters/cppdbg.lua
+++ b/lua/mason-nvim-dap/mappings/adapters/cppdbg.lua
@@ -4,7 +4,7 @@ local M = {
 	command = vim.fn.exepath('OpenDebugAD7'),
 }
 if vim.fn.has('win32') == 1 then
-	M.cppdbg.options = {
+	M.options = {
 		detached = false,
 	}
 end


### PR DESCRIPTION
On Windows, when codelldb and cppdbg are required inside a pcall, the files silently fail to load. The configuration files for these two attempt to add members to "M.codelldb" and "M.cppdbg" respectively, but these two don't exist. The members should instead be added to the top level M table.