### PR TITLE
fix: Default console settings for Python and CodeLLDB

### DIFF
--- a/lua/mason-nvim-dap/mappings/configurations.lua
+++ b/lua/mason-nvim-dap/mappings/configurations.lua
@@ -66,6 +66,7 @@ M.python = {
 		pythonPath = venv_path
 				and ((vim.fn.has('win32') == 1 and venv_path .. '/Scripts/python') or venv_path .. '/bin/python')
 			or nil,
+		console = 'integratedTerminal',
 	},
 }
 
@@ -80,6 +81,7 @@ M.codelldb = {
 		cwd = '${workspaceFolder}',
 		stopOnEntry = false,
 		args = {},
+		console = 'integratedTerminal',
 	},
 }
 


### PR DESCRIPTION
Changed `console` attribute for both the python and codelldb debug adapters to use the `integratedTerminal` setting. This is a more sensible default, as without it tools like `dapui` will assume the REPL should be used - which does not allow for user input.

I have left the other adapters untouched, as I do not have a means of testing the changes right now and have only experienced the problem with Rust (CodeLLDB) and Python.