### PR TITLE
feat: automatically configure the vscode extension in `nvim-dap`

### DIFF
--- a/lua/mason-nvim-dap/init.lua
+++ b/lua/mason-nvim-dap/init.lua
@@ -87,6 +87,10 @@ function M.setup(config)
 		setup_handlers(settings.current.handlers)
 	end
 
+	local dap_vscode = require('dap.ext.vscode')
+	dap_vscode.type_to_filetypes =
+		vim.tbl_deep_extend('force', dap_vscode.type_to_filetypes, require('mason-nvim-dap.mappings.filetypes'))
+
 	require('mason-nvim-dap.api.command')
 end
 


### PR DESCRIPTION
`nvim-dap` provides a vscode extension that loads in `launch.json` files. It has an internal variable for the mappings from adapters to filetypes when loading configurations. This adds automatic support to connect the filetypes to the adapters defined by `nvim-dap`

Here is the variable: https://github.com/mfussenegger/nvim-dap/blob/master/lua/dap/ext/vscode.lua#L6

And here is where they use it: https://github.com/mfussenegger/nvim-dap/blob/master/lua/dap/ext/vscode.lua#L197