### PR TITLE
feat: Add erlang to list of supported debug adapters

### DIFF
--- a/lua/mason-nvim-dap/mappings/adapters/erlang.lua
+++ b/lua/mason-nvim-dap/mappings/adapters/erlang.lua
@@ -1,0 +1,4 @@
+return {
+	type = 'executable',
+	command = vim.fn.exepath('els_dap'),
+}

--- a/lua/mason-nvim-dap/mappings/filetypes.lua
+++ b/lua/mason-nvim-dap/mappings/filetypes.lua
@@ -16,6 +16,7 @@ local M = {
 	['php'] = { 'php' },
 	['python'] = { 'python' },
 	['haskell'] = { 'haskell' },
+	['erlang'] = { 'erlang' },
 }
 
 return M

--- a/lua/mason-nvim-dap/mappings/source.lua
+++ b/lua/mason-nvim-dap/mappings/source.lua
@@ -23,6 +23,7 @@ M.nvim_dap_to_package = {
 	['kotlin'] = 'kotlin-debug-adapter',
 	['dart'] = 'dart-debug-adapter',
 	['haskell'] = 'haskell-debug-adapter',
+	['erlang'] = 'erlang-debugger',
 }
 
 M.package_to_nvim_dap = _.invert(M.nvim_dap_to_package)


### PR DESCRIPTION
I added Erlang to list of adapters. DAP features like breakpoint and REPL are working.