### PR TITLE
fix(php): xdebug port for PHP, resolves #140

### DIFF
--- a/lua/mason-nvim-dap/mappings/configurations.lua
+++ b/lua/mason-nvim-dap/mappings/configurations.lua
@@ -136,7 +136,7 @@ M.php = {
 		type = 'php',
 		request = 'launch',
 		name = 'PHP: Listen for Xdebug',
-		port = 9000,
+		port = 9003,
 	},
 }
 


### PR DESCRIPTION
V3 of Xdebug uses port 9003 by default for step debugging instead of port 9000, this updates the PHP configuration to reflect that.