### PR TITLE
fix: Update bashdb config

### DIFF
--- a/lua/mason-nvim-dap/mappings/configurations.lua
+++ b/lua/mason-nvim-dap/mappings/configurations.lua
@@ -51,6 +51,7 @@ M.bash = {
 		pathPkill = 'pkill',
 		env = {},
 		args = {},
+		terminalKind = 'integrated',
 	},
 }
 


### PR DESCRIPTION
Add `terminalKind = "integrated"` to bashdb config. This fixes the "/dev/stdin: no such device or address" that otherwise shows up when trying to start debugging.