### PR TITLE
refactor(bash): remove reliance on methods that are being deprecated

### DIFF
--- a/lua/mason-nvim-dap/mappings/configurations.lua
+++ b/lua/mason-nvim-dap/mappings/configurations.lua
@@ -41,8 +41,7 @@ if
 	require('mason-registry').has_package('bash-debug-adapter')
 	and require('mason-registry').get_package('bash-debug-adapter'):is_installed()
 then
-	BASHDB_DIR = require('mason-registry').get_package('bash-debug-adapter'):get_install_path()
-		.. '/extension/bashdb_dir'
+	BASHDB_DIR = vim.fn.expand('$MASON/packages/bash-debug-adapter/extension/bashdb_dir')
 end
 
 M.bash = {


### PR DESCRIPTION
There are some big changes coming to Mason and this simply removes reliance on a method that is getting removed in Mason v2.