### PR TITLE
fix(bashdb): rely on `share` directory rather than unsafe package path

### DIFF
--- a/lua/mason-nvim-dap/mappings/configurations.lua
+++ b/lua/mason-nvim-dap/mappings/configurations.lua
@@ -41,7 +41,7 @@ if
 	require('mason-registry').has_package('bash-debug-adapter')
 	and require('mason-registry').get_package('bash-debug-adapter'):is_installed()
 then
-	BASHDB_DIR = vim.fn.expand('$MASON/packages/bash-debug-adapter/extension/bashdb_dir')
+	BASHDB_DIR = vim.fn.expand('$MASON/share/bashdb')
 end
 
 M.bash = {


### PR DESCRIPTION
It is unsafe to rely on paths into the `packages/` directory. I recently got a PR that adds a stable path to the `bashdb` library in Mason which allows us to use a new, stable path for this: https://github.com/mason-org/mason-registry/pull/9018