### PR TITLE
Use vim.validate new signature

### DIFF
--- a/lua/mason-nvim-dap/settings.lua
+++ b/lua/mason-nvim-dap/settings.lua
@@ -26,11 +26,9 @@ M.current = M._DEFAULT_SETTINGS
 ---@param opts MasonNvimDapSettings
 function M.set(opts)
 	M.current = vim.tbl_deep_extend('force', M.current, opts)
-	vim.validate({
-		ensure_installed = { M.current.ensure_installed, 'table', true },
-		automatic_installation = { M.current.automatic_installation, { 'boolean', 'table' }, true },
-		handlers = { M.current.handlers, { 'table' }, true },
-	})
+	vim.validate('ensure_installed', M.current_ensure_installed, 'table', true)
+	vim.validate('automatic_installation', M.current_automatic_installation, { 'boolean', 'table' }, true)
+	vim.validate('handlers', M.current_handlers, 'table', true)
 end
 
 return M


### PR DESCRIPTION
Remove the use of deprecated vim.validate signature in favor of the new one. This change might potentially break neovim configurations using versions prior to 0.9.