### PR TITLE
fix(bashdb): use opt instead of share (fixes #162)

### DIFF
--- a/lua/mason-nvim-dap/mappings/configurations.lua
+++ b/lua/mason-nvim-dap/mappings/configurations.lua
@@ -41,7 +41,7 @@ if
 	require('mason-registry').has_package('bash-debug-adapter')
 	and require('mason-registry').get_package('bash-debug-adapter'):is_installed()
 then
-	BASHDB_DIR = vim.fn.expand('$MASON/share/bashdb')
+	BASHDB_DIR = vim.fn.expand('$MASON/opt/bashdb')
 end
 
 M.bash = {


### PR DESCRIPTION
Mason exposes the bashdb directory in `$MASON/opt`, not `$MASON/share`.

This bug appears to result from a change in the Mason PR (https://github.com/mason-org/mason-registry/pull/9018) from share/ to opt/ not being applied to the mason-nvim-dap PR (https://github.com/jay-babu/mason-nvim-dap.nvim/pull/154).