### PR TITLE
fix: use correct fn for version check (#170)

### DIFF
--- a/lua/mason-nvim-dap/settings.lua
+++ b/lua/mason-nvim-dap/settings.lua
@@ -27,7 +27,7 @@ M.current = M._DEFAULT_SETTINGS
 function M.set(opts)
 	M.current = vim.tbl_deep_extend('force', M.current, opts)
 	-- Check if running Neovim 0.11.2+ for new vim.validate syntax
-	if vim.version('0.11.2') then
+	if vim.fn.has('nvim-0.11.2') == 1 then
 		-- New 0.11.2+ syntax
 		vim.validate('ensure_installed', M.current.ensure_installed, 'table', true)
 		vim.validate('automatic_installation', M.current.automatic_installation, { 'boolean', 'table' }, true)


### PR DESCRIPTION
This fixes (jay-babu#170) by using the `vim.fn.has` fn to check if neovim has the features of `nvim-0.11.2` or later which returns `1` if the version of neovim is `>=` `0.11.2` otherwise it returns `0` if `<` `0.11.2`. This properly checks the truthiness of the feature set by checking if the output is `1` else use the `pre-0.11.2` `vim.validate` for earlier versions of neovim. Tested on `0.11.3`